### PR TITLE
Replace span by link on table details and config actions

### DIFF
--- a/client/src/components/Table/Table.jsx
+++ b/client/src/components/Table/Table.jsx
@@ -15,6 +15,7 @@ import {
   faSort,
   faTrash
 } from '@fortawesome/free-solid-svg-icons';
+import { Link } from 'react-router-dom';
 
 class Table extends Component {
   state = {
@@ -142,10 +143,9 @@ class Table extends Component {
   }
 
   onDoubleClick(onDetails, row) {
-    const { idCol } = this.props;
-
-    if (onDetails) {
-      onDetails(idCol ? row[idCol] : row.id);
+    const { idCol, router, detailsHref } = this.props;
+    if (detailsHref) {
+      router.navigate(detailsHref(idCol ? row[idCol] : row.id));
     }
   }
 
@@ -372,28 +372,16 @@ class Table extends Component {
         )}
         {actions.find(el => el === constants.TABLE_DETAILS) && (
           <td className="khq-row-action khq-row-action-main action-hover">
-            <span
-              title="Details"
-              id="details"
-              onClick={() => {
-                onDetails && onDetails(idColVal);
-              }}
-            >
+            <Link title="Details" id="details" to={this.props.detailsHref(idColVal)}>
               <FontAwesomeIcon icon={faSearch} />
-            </span>
+            </Link>
           </td>
         )}
         {actions.find(el => el === constants.TABLE_CONFIG) && (
           <td className="khq-row-action khq-row-action-main action-hover">
-            <span
-              title="Config"
-              id="config"
-              onClick={() => {
-                onConfig && onConfig(idColVal);
-              }}
-            >
+            <Link title="Config" id="config" to={this.props.configHref(idColVal)}>
               <FontAwesomeIcon icon={faGear} />
-            </span>
+            </Link>
           </td>
         )}
         {actions.find(el => el === constants.TABLE_DELETE) && (
@@ -581,6 +569,8 @@ Table.propTypes = {
 
   onAdd: PropTypes.func,
   onDetails: PropTypes.func,
+  detailsHref: PropTypes.func,
+  configHref: PropTypes.func,
   onConfig: PropTypes.func,
   onDelete: PropTypes.func,
   onEdit: PropTypes.func,

--- a/client/src/components/Table/Table.jsx
+++ b/client/src/components/Table/Table.jsx
@@ -142,7 +142,7 @@ class Table extends Component {
     );
   }
 
-  onDoubleClick(onDetails, row) {
+  onDoubleClick(row) {
     const { idCol, router, detailsHref } = this.props;
     if (detailsHref) {
       router.navigate(detailsHref(idCol ? row[idCol] : row.id));
@@ -156,7 +156,6 @@ class Table extends Component {
       extraRow,
       onExpand,
       noRowBackgroundChange,
-      onDetails,
       handleExtraExpand,
       handleExtraCollapse,
       reduce
@@ -194,7 +193,7 @@ class Table extends Component {
                     actions.find(action => action === constants.TABLE_DETAILS) &&
                     !column.expand
                   ) {
-                    this.onDoubleClick(onDetails, row);
+                    this.onDoubleClick(row);
                   }
 
                   column.expand && this.handleExpand(row);
@@ -216,7 +215,7 @@ class Table extends Component {
                   actions.find(action => action === constants.TABLE_DETAILS) &&
                   !column.expand
                 ) {
-                  this.onDoubleClick(onDetails, row);
+                  this.onDoubleClick(row);
                 }
 
                 column.expand && this.handleExpand(row);
@@ -339,19 +338,8 @@ class Table extends Component {
   }
 
   renderActions(row) {
-    const {
-      actions,
-      onAdd,
-      onDetails,
-      onConfig,
-      onDelete,
-      onEdit,
-      onRestart,
-      onShare,
-      onDownload,
-      onCopy,
-      idCol
-    } = this.props;
+    const { actions, onAdd, onDelete, onEdit, onRestart, onShare, onDownload, onCopy, idCol } =
+      this.props;
 
     let idColVal = idCol ? row[this.props.idCol] : row.id;
 
@@ -568,10 +556,8 @@ Table.propTypes = {
   actions: PropTypes.array,
 
   onAdd: PropTypes.func,
-  onDetails: PropTypes.func,
   detailsHref: PropTypes.func,
   configHref: PropTypes.func,
-  onConfig: PropTypes.func,
   onDelete: PropTypes.func,
   onEdit: PropTypes.func,
   onRestart: PropTypes.func,

--- a/client/src/components/Table/Table.test.jsx
+++ b/client/src/components/Table/Table.test.jsx
@@ -92,12 +92,6 @@ describe('Table', () => {
       onAdd={() => {
         mockFunction(TABLE_ADD);
       }}
-      onDetails={() => {
-        mockFunction(TABLE_DETAILS);
-      }}
-      onConfig={() => {
-        mockFunction(TABLE_CONFIG);
-      }}
       onEdit={() => {
         mockFunction(TABLE_EDIT);
       }}

--- a/client/src/containers/Acl/AclList/Acls.jsx
+++ b/client/src/containers/Acl/AclList/Acls.jsx
@@ -111,9 +111,7 @@ class Acls extends Root {
               </td>
             </tr>
           }
-          onDetails={acl => {
-            this.props.router.navigate(`/ui/${clusterId}/acls/${acl.principalEncoded}`);
-          }}
+          detailsHref={acl => `/ui/${clusterId}/acls/${acl.principalEncoded}`}
         />
       </div>
     );

--- a/client/src/containers/Connect/ConnectList/ConnectList.jsx
+++ b/client/src/containers/Connect/ConnectList/ConnectList.jsx
@@ -341,9 +341,7 @@ class ConnectList extends Root {
             this.setState({ tableData: data });
           }}
           actions={this.getTableActions()}
-          onDetails={name => {
-            this.props.router.navigate(`/ui/${clusterId}/connect/${connectId}/definition/${name}`);
-          }}
+          detailsHref={name => `/ui/${clusterId}/connect/${connectId}/definition/${name}`}
           onDelete={row => {
             this.handleOnDelete(row.id);
           }}

--- a/client/src/containers/ConsumerGroup/ConsumerGroupList/ConsumerGroupList.jsx
+++ b/client/src/containers/ConsumerGroup/ConsumerGroupList/ConsumerGroupList.jsx
@@ -275,9 +275,7 @@ class ConsumerGroupList extends Root {
           onDelete={group => {
             this.handleOnDelete(group);
           }}
-          onDetails={id => {
-            this.props.router.navigate(`/ui/${selectedCluster}/group/${encodeURIComponent(id)}`);
-          }}
+          detailsHref={id => `/ui/${selectedCluster}/group/${encodeURIComponent(id)}`}
           actions={
             roles.CONSUMER_GROUP && roles.CONSUMER_GROUP.includes('DELETE')
               ? [constants.TABLE_DELETE, constants.TABLE_DETAILS]

--- a/client/src/containers/Node/NodeList/NodesList.jsx
+++ b/client/src/containers/Node/NodeList/NodesList.jsx
@@ -113,9 +113,7 @@ class NodesList extends Root {
             this.setState({ data });
           }}
           actions={[constants.TABLE_DETAILS]}
-          onDetails={id => {
-            this.props.router.navigate(`/ui/${selectedCluster}/node/${id}`);
-          }}
+          detailsHref={id => `/ui/${selectedCluster}/node/${id}`}
         />
       </div>
     );

--- a/client/src/containers/Schema/SchemaList/SchemaList.jsx
+++ b/client/src/containers/Schema/SchemaList/SchemaList.jsx
@@ -297,14 +297,9 @@ class SchemaList extends Root {
             this.handleOnDelete(schema);
           }}
           idCol="subject"
-          onDetails={subject => {
-            this.props.router.navigate(
-              {
-                pathname: `/ui/${selectedCluster}/schema/details/${encodeURIComponent(subject)}`
-              },
-              { replace: false }
-            );
-          }}
+          detailsHref={subject =>
+            `/ui/${selectedCluster}/schema/details/${encodeURIComponent(subject)}`
+          }
           actions={
             roles.SCHEMA && roles.SCHEMA.includes('DELETE')
               ? [constants.TABLE_DELETE, constants.TABLE_DETAILS]

--- a/client/src/containers/Topic/Topic/TopicGroups/TopicGroups.jsx
+++ b/client/src/containers/Topic/Topic/TopicGroups/TopicGroups.jsx
@@ -179,14 +179,7 @@ class TopicGroups extends Root {
           updateData={data => {
             this.setState({ consumerGroups: data });
           }}
-          onDetails={id => {
-            this.props.router.navigate(
-              {
-                pathname: `/ui/${selectedCluster}/group/${id}`
-              },
-              { replace: true }
-            );
-          }}
+          detailsHref={id => `/ui/${selectedCluster}/group/${id}`}
           actions={[constants.TABLE_DETAILS]}
         />
       </div>

--- a/client/src/containers/Topic/TopicList/TopicList.jsx
+++ b/client/src/containers/Topic/TopicList/TopicList.jsx
@@ -514,13 +514,11 @@ class TopicList extends Root {
       firstColumns.push({ colName: 'Consumer Groups', colSpan: 1 });
     }
 
-    let onDetailsFunction = undefined;
+    let detailsHref = undefined;
     const actions = [constants.TABLE_CONFIG];
     if (roles.TOPIC_DATA && roles.TOPIC_DATA.includes('READ')) {
       actions.push(constants.TABLE_DETAILS);
-      onDetailsFunction = id => {
-        this.props.router.navigate(`/ui/${selectedCluster}/topic/${id}/data`);
-      };
+      detailsHref = id => `/ui/${selectedCluster}/topic/${id}/data`;
     }
     if (roles.TOPIC && roles.TOPIC.includes('DELETE')) {
       actions.push(constants.TABLE_DELETE);
@@ -582,17 +580,8 @@ class TopicList extends Root {
           onDelete={topic => {
             this.handleOnDelete(topic);
           }}
-          onDetails={onDetailsFunction}
-          onConfig={id => {
-            this.props.router.navigate(
-              {
-                pathname: `/ui/${selectedCluster}/topic/${id}/configs`
-              },
-              {
-                replace: true
-              }
-            );
-          }}
+          detailsHref={detailsHref}
+          configHref={id => `/ui/${selectedCluster}/topic/${id}/configs`}
           actions={actions}
         />
 


### PR DESCRIPTION
A small UX enhancement that allows user to open the topic data page (or any details page), topic configuration page (on any configuration page) in a new browser tab with CTRL+Click, CMD+Click, Right-click + Open in a new tab. People can be frustrated when working on several topics because they can't (easily) open 2 topics in 2 different tabs. 

Before:
<img width="315" height="105" alt="image" src="https://github.com/user-attachments/assets/52e79e41-0d18-4eff-bb43-8af3d5728e5b" />

After:
<img width="315" height="105" alt="image" src="https://github.com/user-attachments/assets/7d294f1d-037f-4702-b895-24e9a17442ef" />
